### PR TITLE
fix(logging): eliminate duplicate sends and use sync file destination

### DIFF
--- a/convex/lib/log.ts
+++ b/convex/lib/log.ts
@@ -22,6 +22,8 @@ type ConvexLogger = {
 	warn: (msg: string, context?: LogContext) => void;
 	error: (msg: string, context?: LogContext) => void;
 	fatal: (msg: string, context?: LogContext) => void;
+	child: (bindings: LogContext) => ConvexLogger;
+	flush: () => void;
 };
 
 export const LOG_MARKER = "__VINCI_LOG__";
@@ -67,6 +69,8 @@ export function createConvexLogger(bindings: LogContext = {}): ConvexLogger {
 		warn: createLogMethod("warn", bindings),
 		error: createLogMethod("error", bindings),
 		fatal: createLogMethod("fatal", bindings),
+		child: (childBindings) => createConvexLogger({ ...bindings, ...childBindings }),
+		flush: () => {},
 	};
 }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"pino": "^10.1.0",
 		"react": "19.2.3",
 		"react-dom": "19.2.3",
-		"rotating-file-stream": "^3.2.7",
 		"tailwind-merge": "^3.4.0"
 	},
 	"devDependencies": {

--- a/tests/unit/logger-client.test.ts
+++ b/tests/unit/logger-client.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import {
+	clientLogger,
+	createClientLogger,
+	initClientErrorHandlers,
+	isClientErrorHandlersInitialized,
+	resetClientErrorHandlers,
+} from "@/lib/logging/logger-client";
+
+describe("Client Logger", () => {
+	let originalFetch: typeof fetch;
+	let fetchCalls: Array<{ url: string; options: RequestInit }>;
+
+	beforeEach(() => {
+		// #given - mock fetch to track calls
+		fetchCalls = [];
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = mock((url: string | URL | Request, options?: RequestInit) => {
+			fetchCalls.push({ url: String(url), options: options ?? {} });
+			return Promise.resolve(new Response(JSON.stringify({ success: true })));
+		}) as unknown as typeof fetch;
+
+		resetClientErrorHandlers();
+	});
+
+	afterEach(() => {
+		// #cleanup
+		globalThis.fetch = originalFetch;
+		resetClientErrorHandlers();
+	});
+
+	describe("createClientLogger", () => {
+		it("#given logger created #when info called #then does NOT send to server", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.info("Test info");
+
+			// #then - info level should not trigger sendToServer
+			expect(fetchCalls.length).toBe(0);
+		});
+
+		it("#given logger created #when error called #then sends to server once", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.error("Test error");
+
+			// #then - should send exactly ONE request
+			expect(fetchCalls.length).toBe(1);
+			expect(fetchCalls[0]?.url).toBe("/api/log");
+		});
+
+		it("#given logger created #when warn called #then sends to server once", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.warn("Test warning");
+
+			// #then - should send exactly ONE request
+			expect(fetchCalls.length).toBe(1);
+		});
+
+		it("#given logger with bindings #when child created #then child inherits bindings", () => {
+			// #given
+			const logger = createClientLogger({ userId: "user-1" });
+
+			// #when
+			const childLogger = logger.child({ requestId: "req-1" });
+			childLogger.error("Child error");
+
+			// #then - payload should contain both bindings
+			const payload = JSON.parse(fetchCalls[0]?.options.body as string);
+			expect(payload.userId).toBe("user-1");
+			expect(payload.requestId).toBe("req-1");
+		});
+
+		it("#given logger #when flush called #then does not throw", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when/#then - flush is no-op but should not throw
+			expect(() => logger.flush()).not.toThrow();
+		});
+
+		it("#given logger #when fatal called #then sends to server", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.fatal("Fatal error");
+
+			// #then - should send request
+			expect(fetchCalls.length).toBe(1);
+		});
+
+		it("#given logger #when trace called #then does NOT send to server", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.trace("Trace message");
+
+			// #then
+			expect(fetchCalls.length).toBe(0);
+		});
+
+		it("#given logger #when debug called #then does NOT send to server", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.debug("Debug message");
+
+			// #then
+			expect(fetchCalls.length).toBe(0);
+		});
+	});
+
+	describe("Duplicate logging prevention (CRITICAL)", () => {
+		let consoleErrorSpy: ReturnType<typeof spyOn>;
+		let consoleWarnSpy: ReturnType<typeof spyOn>;
+
+		beforeEach(() => {
+			// #given - setup console spies
+			consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+			consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		});
+
+		afterEach(() => {
+			// #cleanup
+			consoleErrorSpy.mockRestore();
+			consoleWarnSpy.mockRestore();
+		});
+
+		it("#given handlers initialized #when clientLogger.error called #then only ONE network request", () => {
+			// #given - initialize error handlers (which monkey-patch console)
+			// HappyDOM provides window, so handlers can initialize
+			initClientErrorHandlers();
+			expect(isClientErrorHandlersInitialized()).toBe(true);
+
+			// #when - call clientLogger.error
+			clientLogger.error("This should send ONLY ONE request");
+
+			// #then - CRITICAL: should be exactly 1 request, NOT 2
+			expect(fetchCalls.length).toBe(1);
+		});
+
+		it("#given handlers initialized #when clientLogger.warn called #then only ONE network request", () => {
+			// #given
+			initClientErrorHandlers();
+
+			// #when
+			clientLogger.warn("This should send ONLY ONE request");
+
+			// #then
+			expect(fetchCalls.length).toBe(1);
+		});
+
+		it("#given handlers NOT initialized #when console.error called directly #then NO server send", () => {
+			// #given - handlers NOT initialized, console.error is not patched
+			expect(isClientErrorHandlersInitialized()).toBe(false);
+
+			// #when - call console.error directly
+			console.error("Direct console error without handlers");
+
+			// #then - no fetch should happen since handlers aren't initialized
+			expect(fetchCalls.length).toBe(0);
+		});
+
+		it("#given handlers initialized #when console.error called directly #then sends to server", () => {
+			// #given - initialize handlers
+			initClientErrorHandlers();
+
+			// #when - call console.error directly (not through logger)
+			console.error("Direct console error");
+
+			// #then - should send to server (user's console.error should be forwarded)
+			expect(fetchCalls.length).toBe(1);
+		});
+
+		it("#given handlers initialized #when console.warn called directly #then sends to server", () => {
+			// #given
+			initClientErrorHandlers();
+
+			// #when
+			console.warn("Direct console warn");
+
+			// #then
+			expect(fetchCalls.length).toBe(1);
+		});
+
+		it("#given logger.error and direct console.error #when both called #then each sends ONE request", () => {
+			// #given
+			initClientErrorHandlers();
+
+			// #when - call both
+			clientLogger.error("Logger error");
+			console.error("Direct console error");
+
+			// #then - should be exactly 2 requests (1 from logger, 1 from direct console)
+			expect(fetchCalls.length).toBe(2);
+		});
+	});
+
+	describe("Log entry structure", () => {
+		it("#given logger #when error logged #then entry has required fields", () => {
+			// #given
+			const logger = createClientLogger();
+
+			// #when
+			logger.error("Structure test");
+
+			// #then
+			const payload = JSON.parse(fetchCalls[0]?.options.body as string);
+			expect(payload).toHaveProperty("level", "error");
+			expect(payload).toHaveProperty("msg", "Structure test");
+			expect(payload).toHaveProperty("time");
+			expect(payload).toHaveProperty("service", "vinci-client");
+		});
+
+		it("#given logger with error context #when logged #then formats error object", () => {
+			// #given
+			const logger = createClientLogger();
+			const testError = new Error("Test error message");
+			testError.name = "TestError";
+
+			// #when
+			logger.error("Error occurred", { error: testError });
+
+			// #then
+			const payload = JSON.parse(fetchCalls[0]?.options.body as string);
+			expect(payload.error).toBeDefined();
+			expect(payload.error.name).toBe("TestError");
+			expect(payload.error.message).toBe("Test error message");
+		});
+	});
+
+	describe("resetClientErrorHandlers", () => {
+		it("#given handlers initialized #when reset #then isInitialized returns false", () => {
+			// #given - HappyDOM provides window, so handlers can initialize
+			initClientErrorHandlers();
+			expect(isClientErrorHandlersInitialized()).toBe(true);
+
+			// #when
+			resetClientErrorHandlers();
+
+			// #then
+			expect(isClientErrorHandlersInitialized()).toBe(false);
+		});
+	});
+});

--- a/tests/unit/logger-edge.test.ts
+++ b/tests/unit/logger-edge.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { createEdgeLogger, edgeLogger } from "@/lib/logging/logger-edge";
+
+describe("Edge Logger", () => {
+	let consoleDebugSpy: ReturnType<typeof spyOn>;
+	let consoleInfoSpy: ReturnType<typeof spyOn>;
+	let consoleWarnSpy: ReturnType<typeof spyOn>;
+	let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		consoleDebugSpy = spyOn(console, "debug").mockImplementation(() => {});
+		consoleInfoSpy = spyOn(console, "info").mockImplementation(() => {});
+		consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleDebugSpy.mockRestore();
+		consoleInfoSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	describe("createEdgeLogger", () => {
+		it("#given edge logger #when info called #then outputs to console.info", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.info("Test message");
+
+			// #then
+			expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output.msg).toBe("Test message");
+			expect(output.runtime).toBe("edge");
+		});
+
+		it("#given edge logger #when trace called #then outputs to console.debug", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.trace("Trace message");
+
+			// #then
+			expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("#given edge logger #when debug called #then outputs to console.debug", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.debug("Debug message");
+
+			// #then
+			expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("#given edge logger #when warn called #then outputs to console.warn", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.warn("Warning message");
+
+			// #then
+			expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+			const output = JSON.parse(consoleWarnSpy.mock.calls[0]?.[0] as string);
+			expect(output.level).toBe("warn");
+		});
+
+		it("#given edge logger #when error called #then outputs to console.error", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.error("Error message");
+
+			// #then
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+			const output = JSON.parse(consoleErrorSpy.mock.calls[0]?.[0] as string);
+			expect(output.level).toBe("error");
+		});
+
+		it("#given edge logger #when fatal called #then outputs to console.error", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.fatal("Fatal message");
+
+			// #then
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+			const output = JSON.parse(consoleErrorSpy.mock.calls[0]?.[0] as string);
+			expect(output.level).toBe("fatal");
+		});
+
+		it("#given edge logger with bindings #when log called #then includes bindings", () => {
+			// #given
+			const logger = createEdgeLogger({ traceId: "trace-123" });
+
+			// #when
+			logger.info("Message with bindings");
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output.traceId).toBe("trace-123");
+		});
+
+		it("#given edge logger #when context passed #then merges with bindings", () => {
+			// #given
+			const logger = createEdgeLogger({ traceId: "trace-123" });
+
+			// #when
+			logger.info("Merged message", { userId: "user-1" });
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output.traceId).toBe("trace-123");
+			expect(output.userId).toBe("user-1");
+		});
+	});
+
+	describe("child() method", () => {
+		it("#given edge logger #when child created #then inherits parent bindings", () => {
+			// #given
+			const logger = createEdgeLogger({ traceId: "trace-123" });
+
+			// #when
+			const child = logger.child({ userId: "user-1" });
+			child.info("Child message");
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output.traceId).toBe("trace-123");
+			expect(output.userId).toBe("user-1");
+		});
+
+		it("#given child logger #when context overrides parent #then child context wins", () => {
+			// #given
+			const logger = createEdgeLogger({ traceId: "parent-trace" });
+
+			// #when
+			const child = logger.child({ traceId: "child-trace" });
+			child.info("Override test");
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output.traceId).toBe("child-trace");
+		});
+
+		it("#given child logger #when grandchild created #then all bindings inherited", () => {
+			// #given
+			const logger = createEdgeLogger({ traceId: "trace-123" });
+			const child = logger.child({ userId: "user-1" });
+
+			// #when
+			const grandchild = child.child({ requestId: "req-1" });
+			grandchild.info("Grandchild message");
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output.traceId).toBe("trace-123");
+			expect(output.userId).toBe("user-1");
+			expect(output.requestId).toBe("req-1");
+		});
+	});
+
+	describe("flush() method", () => {
+		it("#given edge logger #when flush called #then does not throw", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when/#then
+			expect(() => logger.flush()).not.toThrow();
+		});
+	});
+
+	describe("Log entry structure", () => {
+		it("#given edge logger output #when parsed #then has runtime field set to edge", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.warn("Structure test");
+
+			// #then
+			const output = JSON.parse(consoleWarnSpy.mock.calls[0]?.[0] as string);
+			expect(output.runtime).toBe("edge");
+			expect(output.service).toBe("vinci-edge");
+		});
+
+		it("#given edge logger output #when parsed #then has required fields", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.info("Required fields test");
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			expect(output).toHaveProperty("level", "info");
+			expect(output).toHaveProperty("msg", "Required fields test");
+			expect(output).toHaveProperty("time");
+			expect(output).toHaveProperty("service", "vinci-edge");
+			expect(output).toHaveProperty("runtime", "edge");
+		});
+
+		it("#given edge logger time field #when parsed #then is valid ISO timestamp", () => {
+			// #given
+			const logger = createEdgeLogger();
+
+			// #when
+			logger.info("Time test");
+
+			// #then
+			const output = JSON.parse(consoleInfoSpy.mock.calls[0]?.[0] as string);
+			const parsedTime = new Date(output.time);
+			expect(parsedTime.toISOString()).toBe(output.time);
+		});
+	});
+
+	describe("edgeLogger singleton", () => {
+		it("#given edgeLogger #when used #then works correctly", () => {
+			// #given - edgeLogger is exported singleton
+			// #when
+			edgeLogger.info("Singleton test");
+
+			// #then
+			expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+});


### PR DESCRIPTION
- Add isInternalLogging guard to prevent recursive log sends
- Replace rotating-file-stream with Pino's native sync destination
- Add child() and flush() methods to Convex/Edge loggers for API parity
- Add date-based cache invalidation for daily log file rotation