### PR TITLE
fix: resolve SonarCloud false positives and CardTitle a11y issue

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,11 +4,22 @@ sonar.organization=ravindrabarthwal
 # Source encoding
 sonar.sourceEncoding=UTF-8
 
-# Source directories
+# Source directories (explicit - only analyze src and convex)
 sonar.sources=src,convex
 
-# Exclusions
-sonar.exclusions=**/node_modules/**,**/*.test.ts,**/*.test.tsx,**/convex/_generated/**,**/convex/betterAuth/_generated/**,**/.next/**,**/dist/**,**/build/**,**/coverage/**,scripts/**
+# Exclusions - comprehensive list
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/convex/_generated/**,\
+  **/convex/betterAuth/_generated/**,\
+  **/.next/**,\
+  **/dist/**,\
+  **/build/**,\
+  **/coverage/**,\
+  scripts/**,\
+  **/scripts/**
 
 # Test directories
 sonar.tests=tests,convex
@@ -16,3 +27,21 @@ sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
 
 # TypeScript
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
+
+# Issue ignores for false positives and generated code
+# Ignore CSS unknown at-rule for Tailwind v4 directives
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+
+# @custom-variant is a valid Tailwind v4 directive (false positive)
+sonar.issue.ignore.multicriteria.e1.ruleKey=css:S4662
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/globals.css
+
+# Generated Convex files - ignore eslint-disable warnings
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S7724
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/convex/_generated/**
+
+sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S7724
+sonar.issue.ignore.multicriteria.e3.resourceKey=**/convex/betterAuth/_generated/**
+
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S7724
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/convex/_generated/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,11 +4,22 @@ sonar.organization=ravindrabarthwal
 # Source encoding
 sonar.sourceEncoding=UTF-8
 
-# Source directories
+# Source directories (explicit - only analyze src and convex)
 sonar.sources=src,convex
 
-# Exclusions
-sonar.exclusions=**/node_modules/**,**/*.test.ts,**/*.test.tsx,**/convex/_generated/**,**/convex/betterAuth/_generated/**,**/.next/**,**/dist/**,**/build/**,**/coverage/**,scripts/**
+# Exclusions - comprehensive list
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/convex/_generated/**,\
+  **/convex/betterAuth/_generated/**,\
+  **/.next/**,\
+  **/dist/**,\
+  **/build/**,\
+  **/coverage/**,\
+  scripts/**,\
+  **/scripts/**
 
 # Test directories
 sonar.tests=tests,convex
@@ -16,3 +27,21 @@ sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
 
 # TypeScript
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
+
+# Issue ignores for false positives and generated code
+# Ignore CSS unknown at-rule for Tailwind v4 directives
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
+
+# @custom-variant is a valid Tailwind v4 directive (false positive)
+sonar.issue.ignore.multicriteria.e1.ruleKey=css:S4662
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/globals.css
+
+# Generated Convex files - ignore eslint-disable warnings
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S7724
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/convex/_generated/**
+
+sonar.issue.ignore.multicriteria.e3.ruleKey=typescript:S7724
+sonar.issue.ignore.multicriteria.e3.resourceKey=**/convex/betterAuth/_generated/**
+
+sonar.issue.ignore.multicriteria.e4.ruleKey=javascript:S7724
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/convex/_generated/**

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -28,13 +28,15 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
 	);
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"h2">) {
+interface CardTitleProps extends Omit<React.ComponentProps<"h2">, "children"> {
+	children: React.ReactNode;
+}
+
+function CardTitle({ className, children, ...props }: Readonly<CardTitleProps>) {
 	return (
-		<h2
-			data-slot="card-title"
-			className={cn("leading-tight font-semibold", className)}
-			{...props}
-		/>
+		<h2 data-slot="card-title" className={cn("leading-tight font-semibold", className)} {...props}>
+			{children}
+		</h2>
 	);
 }
 


### PR DESCRIPTION
- Add issue ignore rules for Tailwind v4 @custom-variant directive (css:S4662)
- Add issue ignore rules for generated Convex files (typescript:S7724, javascript:S7724)
- Improve sonar.exclusions format with multiline for better parsing
- Fix CardTitle accessibility: make children prop required to ensure heading content

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->