### PR TITLE
fix(e2e): use correct Convex site URL port (3211) for HTTP actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,8 @@ jobs:
       BETTER_AUTH_SECRET: ci-test-secret-key-minimum-32-characters-long
       BETTER_AUTH_URL: http://localhost:3000
       NEXT_PUBLIC_CONVEX_URL: http://127.0.0.1:3210
-      NEXT_PUBLIC_CONVEX_SITE_URL: http://127.0.0.1:3210
+      # HTTP Actions (including /health) are served on port 3211, not 3210
+      NEXT_PUBLIC_CONVEX_SITE_URL: http://127.0.0.1:3211
       CONVEX_AGENT_MODE: anonymous
     steps:
       - uses: actions/checkout@v5
@@ -144,7 +145,7 @@ jobs:
           BETTER_AUTH_SECRET=ci-test-secret-key-minimum-32-characters-long
           BETTER_AUTH_URL=http://localhost:3000
           NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
-          NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3210
+          NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3211
           EOF
 
       - name: Run E2E tests
@@ -155,7 +156,7 @@ jobs:
           BETTER_AUTH_SECRET: ci-test-secret-key-minimum-32-characters-long
           BETTER_AUTH_URL: http://localhost:3000
           NEXT_PUBLIC_CONVEX_URL: http://127.0.0.1:3210
-          NEXT_PUBLIC_CONVEX_SITE_URL: http://127.0.0.1:3210
+          NEXT_PUBLIC_CONVEX_SITE_URL: http://127.0.0.1:3211
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,33 +1,60 @@
+import { exec } from "node:child_process";
 import path from "node:path";
+import { promisify } from "node:util";
 import { expect, test as setup } from "@playwright/test";
 
+const execAsync = promisify(exec);
 const authFile = path.join(__dirname, ".auth/user.json");
 
-/**
- * Wait for Convex backend to be ready by polling the health endpoint.
- * The health endpoint returns 200 when Convex functions are deployed and ready.
- */
-async function waitForConvexBackend(maxWaitMs = 60000): Promise<void> {
-	const convexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_SITE_URL ?? "http://127.0.0.1:3210";
+async function setConvexEnvVar(): Promise<void> {
+	if (!process.env.CI) return;
+
+	const secret = process.env.BETTER_AUTH_SECRET;
+	if (!secret) {
+		console.log("[E2E Setup] No BETTER_AUTH_SECRET in environment, skipping Convex env set");
+		return;
+	}
+
+	try {
+		console.log("[E2E Setup] Setting BETTER_AUTH_SECRET in Convex environment...");
+		await execAsync(`bunx convex env set BETTER_AUTH_SECRET "${secret}"`);
+		console.log("[E2E Setup] Successfully set BETTER_AUTH_SECRET in Convex");
+	} catch (error) {
+		console.error("[E2E Setup] Failed to set Convex env var:", error);
+	}
+}
+
+async function waitForConvexBackend(maxWaitMs = 90000): Promise<void> {
+	const convexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_SITE_URL ?? "http://127.0.0.1:3211";
 	const healthUrl = `${convexSiteUrl}/health`;
 	const startTime = Date.now();
-	const pollIntervalMs = 1000;
+	const pollIntervalMs = 2000;
+
+	console.log(`[E2E Setup] Waiting for Convex backend at ${healthUrl}...`);
 
 	while (Date.now() - startTime < maxWaitMs) {
 		try {
 			const response = await fetch(healthUrl);
 			if (response.ok) {
+				const elapsed = Date.now() - startTime;
+				console.log(`[E2E Setup] Convex backend ready after ${elapsed}ms`);
 				return;
 			}
-		} catch {
-			// Network error or Convex not ready yet, keep waiting
+			const text = await response.text().catch(() => "");
+			console.log(`[E2E Setup] Health check returned ${response.status}: ${text.slice(0, 100)}`);
+		} catch (error) {
+			const elapsed = Date.now() - startTime;
+			console.log(`[E2E Setup] Health check failed after ${elapsed}ms: ${error}`);
 		}
 		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
 	}
-	throw new Error(`Convex backend did not become ready within ${maxWaitMs}ms`);
+	throw new Error(
+		`Convex backend did not become ready within ${maxWaitMs}ms (polling ${healthUrl})`,
+	);
 }
 
 setup("authenticate", async ({ page }) => {
+	await setConvexEnvVar();
 	await waitForConvexBackend();
 
 	const uniqueId = `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;


### PR DESCRIPTION
### **User description**
## Summary

Fixes the E2E test timeout issue in PR #23 by using the correct port for Convex HTTP actions.

### Root Cause

The Convex local backend exposes two ports:
- **Port 3210**: Client API (queries, mutations)
- **Port 3211**: HTTP Actions (including `/health` endpoint)

The CI workflow was setting `NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3210`, but the `/health` endpoint (defined in `convex/http.ts`) is served on port **3211**.

### Changes

1. **`.github/workflows/test.yaml`**: Updated `NEXT_PUBLIC_CONVEX_SITE_URL` from 3210 to 3211 in all three locations:
   - Job-level environment variables
   - `.env.local` creation step  
   - Test step environment variables

2. **`e2e/auth.setup.ts`**:
   - Added `setConvexEnvVar()` to set `BETTER_AUTH_SECRET` in Convex environment via CLI
   - Added detailed console logging for debugging health check polling
   - Updated default fallback port from 3210 to 3211
   - Increased timeout from 60s to 90s and poll interval from 1s to 2s

### Testing

Validated locally that:
- `curl http://127.0.0.1:3210/health` → 404 Not Found
- `curl http://127.0.0.1:3211/health` → 200 OK `{"status":"ok"}`

Relates to #23


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed E2E test timeout by correcting Convex HTTP actions port from 3210 to 3211

- Added `setConvexEnvVar()` function to set `BETTER_AUTH_SECRET` in Convex environment

- Enhanced health check polling with detailed console logging for debugging

- Increased timeout from 60s to 90s and poll interval from 1s to 2s


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Convex Local Backend<br/>Port 3210: Client API<br/>Port 3211: HTTP Actions"] -->|"Health endpoint<br/>on port 3211"| B["Updated Configuration"]
  B -->|"3 locations in<br/>test.yaml"| C["CI Workflow"]
  B -->|"Default fallback<br/>port 3211"| D["auth.setup.ts"]
  D -->|"New function"| E["setConvexEnvVar"]
  D -->|"Enhanced logging"| F["waitForConvexBackend"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.setup.ts</strong><dd><code>Add Convex env setup and enhance health check logging</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/auth.setup.ts

<ul><li>Added <code>setConvexEnvVar()</code> function to set <code>BETTER_AUTH_SECRET</code> in Convex <br>environment via CLI<br> <li> Updated default fallback port from 3210 to 3211 in <br><code>waitForConvexBackend()</code><br> <li> Increased timeout from 60s to 90s and poll interval from 1s to 2s<br> <li> Added comprehensive console logging for health check polling and <br>debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/ravindrabarthwal/vinci/pull/24/files#diff-15b444c41b23a2e0f9b8e6827c55264d5fcd7a934cccda63a6b700ec7f81411b">+37/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.yaml</strong><dd><code>Update Convex site URL port to 3211 in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test.yaml

<ul><li>Updated <code>NEXT_PUBLIC_CONVEX_SITE_URL</code> from port 3210 to 3211 in <br>job-level environment variables<br> <li> Updated <code>NEXT_PUBLIC_CONVEX_SITE_URL</code> from port 3210 to 3211 in <br><code>.env.local</code> creation step<br> <li> Updated <code>NEXT_PUBLIC_CONVEX_SITE_URL</code> from port 3210 to 3211 in test <br>step environment variables<br> <li> Added clarifying comment explaining HTTP Actions are served on port <br>3211</ul>


</details>


  </td>
  <td><a href="https://github.com/ravindrabarthwal/vinci/pull/24/files#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

