### PR TITLE
fix(e2e): use unique identifier for organization name in signup test

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -71,7 +71,7 @@ setup("authenticate", async ({ page }) => {
 
 	await expect(page).toHaveURL("/org/new", { timeout: 15000 });
 
-	await page.getByLabel("Organization Name").fill("Test Organization");
+	await page.getByLabel("Organization Name").fill(`Test Organization ${uniqueId}`);
 	await page.getByRole("button", { name: "Create Organization" }).click();
 
 	await expect(page).toHaveURL("/dashboard", { timeout: 15000 });


### PR DESCRIPTION
### **User description**
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use unique identifier in organization name during signup test

- Prevents test failures from duplicate organization names

- Ensures test isolation and reliability in e2e authentication flow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Organization Name Input"] -- "Add uniqueId suffix" --> B["Test Organization {uniqueId}"]
  B -- "Prevents duplicates" --> C["Reliable E2E Test"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.setup.ts</strong><dd><code>Add unique identifier to organization name input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

e2e/auth.setup.ts

<ul><li>Modified organization name input to include <code>uniqueId</code> variable<br> <li> Changes from static "Test Organization" to dynamic <code>Test Organization </code><br><code>${uniqueId}</code><br> <li> Ensures unique organization names across multiple test runs<br> <li> Prevents test failures due to duplicate organization name conflicts</ul>


</details>


  </td>
  <td><a href="https://github.com/ravindrabarthwal/vinci/pull/25/files#diff-15b444c41b23a2e0f9b8e6827c55264d5fcd7a934cccda63a6b700ec7f81411b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

